### PR TITLE
fix: start() rejection on login-error emitted

### DIFF
--- a/packages/guard/src/index.tsx
+++ b/packages/guard/src/index.tsx
@@ -232,15 +232,13 @@ export class Guard {
 
     const userInfo = await this.trackSession()
 
-    if (userInfo) {
-      return Promise.resolve(userInfo)
-    }
-
-    return new Promise(resolve => {
-      this.on('login', (userInfo: User) => {
-        resolve(userInfo)
+    return (
+      userInfo ||
+      new Promise<User>((resolve, reject) => {
+        this.on('login', resolve)
+        this.on('login-error', reject)
       })
-    })
+    )
   }
 
   startRegister() {


### PR DESCRIPTION
## Description

Fix `guard.start()`'s rejection on `login-error` event emitted

## Checklist

- [x] the pull request title describes what this PR does (not a vague title like `Update readme.md`)
- [ ] the pull request targets the *default* branch of the repository (`develop`)
- [ ] the code follows the established code style of the repository, such as:
  - `npm run prettier:check` passes
  - `npm run eslint:check` passes
- [ ] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors